### PR TITLE
lsコマンド3作成

### DIFF
--- a/04.ls/ls_1
+++ b/04.ls/ls_1
@@ -12,6 +12,9 @@ def check_option
   opt.on('-a') do |all_files|
     options[:all_files] = all_files
   end
+  opt.on('-r') do |return_files|
+    options[:return_files] = return_files
+  end
   opt.parse!(ARGV)
   options
 end
@@ -23,11 +26,13 @@ end
 
 def files_to_matrix(options)
   files = fetch_files(options[:all_files])
+  files = files.reverse if options[:return_files]
   sliced_files = files.each_slice(COL_FULL_SIZE).to_a
   # 配列内の要素が3つに揃うように空白を追加
   sliced_files.each do |cols|
     cols.concat([''] * (COL_FULL_SIZE - cols.size)) if cols.size < COL_FULL_SIZE
   end
+  sliced_files
 end
 
 def print_file(matrix)

--- a/04.ls/ls_1
+++ b/04.ls/ls_1
@@ -12,8 +12,8 @@ def check_option
   opt.on('-a') do |all_files|
     options[:all_files] = all_files
   end
-  opt.on('-r') do |return_files|
-    options[:return_files] = return_files
+  opt.on('-r') do |reverse_files|
+    options[:reverse_files] = reverse_files
   end
   opt.parse!(ARGV)
   options
@@ -26,7 +26,7 @@ end
 
 def files_to_matrix(options)
   files = fetch_files(options[:all_files])
-  files = files.reverse if options[:return_files]
+  files = files.reverse if options[:reverse_files]
   sliced_files = files.each_slice(COL_FULL_SIZE).to_a
   # 配列内の要素が3つに揃うように空白を追加
   sliced_files.each do |cols|


### PR DESCRIPTION
`files_to_matrix(options)`のメソッド内で`files.reverse! if options[:return_files]`と破壊的変更とするか悩みましたが、`files`変数に再代入することで、今後のプラクティスで必須となる`-r-` `-a`オプションの併用に対応できる形にしました。
変数の再代入が適さない場合はご指摘いただけると助かります。

ご確認よろしくお願いします。